### PR TITLE
fix null in notification message

### DIFF
--- a/nobody_home.groovy
+++ b/nobody_home.groovy
@@ -226,7 +226,7 @@ def presenceHandler(evt)
 
     // is setInitialMode() still pending?
     if (state.pendingOp == "init") {
-        log.debug("pending ${state.pendingOp} op still in progress, ignoring presence event")
+        log.debug("Pending ${state.pendingOp} op still in progress, ignoring presence event")
         return
     }
 
@@ -252,7 +252,7 @@ def handleDeparture()
     // pending, and scheduling delaySetMode() has the nice effect of
     // canceling any previous pending timer, which is what we want to
     // do. So we do this even if delay is 0.
-    log.info("Scheduling ${newAwayMode} mode in " + state.awayDelay + 's')
+    log.info("Scheduling ${newAwayMode} mode in " + state.awayDelay + "s")
     state.pendingOp = "away"
     state.timerDevice = state.eventDevice
     // we always use runIn(). This has the benefit of automatically
@@ -289,12 +289,12 @@ def handleArrival()
     // extended when the 2nd person arrives later. this should not
     // happen because of the >1 check above, but just in case.
     if (state.pendingOp == "arrive") {
-        log.debug("pending ${state.pendingOp} op already in progress, do nothing")
+        log.debug("Pending ${state.pendingOp} op already in progress, do nothing")
         return
     }
 
     // now we set home/night mode
-    log.info("Scheduling ${state.modeIfHome} mode in " + state.arrivalDelay + 's')
+    log.info("Scheduling ${state.modeIfHome} mode in " + state.arrivalDelay + "s")
     state.pendingOp = "arrive"
     state.timerDevice = state.eventDevice
     // if any away timer is active, it will be clobbered with

--- a/nobody_home.groovy
+++ b/nobody_home.groovy
@@ -339,6 +339,9 @@ def reasonStr(isAway, delaySec, delayMin)
 
     if (delaySec) {
         if (delaySec > 60) {
+            if (delayMin == null) {
+                delayMin = (int) delaySec / 60
+            }
             reason += " ${delayMin} minutes ago"
         } else {
             reason += " ${delaySec}s ago"


### PR DESCRIPTION
When user uses default delay threshold, the notification message will say something like "... null minutes ago" instead of "... 2 minutes ago".

This is because setting settings.arrivalThreshold in initialize() does not seem to affect the global arrivalThreshold value we use later. We want to use arrivalThreshold instead of compute from delaySec because if arrivalThreshold is a decimal, the conversion won't be exact.

Tested with arrival/departure at default value.
